### PR TITLE
Fix double-printing error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,6 @@ var osExit = os.Exit
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		rootCmd.Println(err)
 		osExit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,8 +14,9 @@ func init() {
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:  "fiber",
-	Long: "🚀 Fiber is an Express inspired web framework written in Go with 💖\n Learn more on https://gofiber.io",
+	Use:           "fiber",
+	Long:          "🚀 Fiber is an Express inspired web framework written in Go with 💖\n Learn more on https://gofiber.io",
+	SilenceErrors: true,
 }
 
 var osExit = os.Exit
@@ -24,6 +25,7 @@ var osExit = os.Exit
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		rootCmd.Println(err)
 		osExit(1)
 	}
 }


### PR DESCRIPTION
Makes errors only print once. Fixes:

```bash
❯ go run fiber/main.go xyz
Error: unknown command "xyz" for "fiber"
Run 'fiber --help' for usage.
unknown command "xyz" for "fiber"
exit status 1
```

to

```bash
❯ go run fiber/main.go xyz
Error: unknown command "xyz" for "fiber"
Run 'fiber --help' for usage.
exit status 1
```